### PR TITLE
新規登録ページのエラーメッセージ修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,4 @@ gem "jquery-rails"
 gem "simplecov"
 gem "factory_bot_rails"
 gem 'rails-controller-testing'
+gem "rails-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.1.6)
       actionpack (= 5.1.6)
       activesupport (= 5.1.6)
@@ -299,6 +302,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.6)
   rails-controller-testing
+  rails-i18n
   rspec (>= 3.0.0)
   rspec-rails
   rubocop

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for @user do |f|
   - if @user.errors.any?
     #error_explanation
-      %h2= "#{pluralize(@user.errors.count, "error")} prohibited this user from being saved:"
+      %h2= "#{@user.errors.count} つのエラー"
       %ul
         - @user.errors.full_messages.each do |message|
           %li= message

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module Pilotprojectwiki
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module Pilotprojectwiki
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-    config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,6 @@ module Pilotprojectwiki
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        name: 名前
+        email: メールアドレス
+        passwoed: パスワード

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -7,3 +7,4 @@ ja:
         name: 名前
         email: メールアドレス
         password: パスワード
+        password_confirmation: もう一度パスワードを入力して下さいお願いします!!!!!!!!!!!!!!!!!!!!!!

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -6,4 +6,4 @@ ja:
       user:
         name: 名前
         email: メールアドレス
-        passwoed: パスワード
+        password: パスワード

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -7,4 +7,4 @@ ja:
         name: 名前
         email: メールアドレス
         password: パスワード
-        password_confirmation: もう一度パスワードを入力して下さいお願いします!!!!!!!!!!!!!!!!!!!!!!
+        password_confirmation: もう一度入力 


### PR DESCRIPTION
# 目的
新規登録ページのエラーメッセージなどを日本語化する

# やったこと
gem(rails-i18n)を追加してapplication.rbに設定を追加、エラーに対応する辞書を配置
form.hamlのメッセージを英語から日本語に変更

# 今の見た目
<img width="1440" alt="2018-06-15 10 25 15" src="https://user-images.githubusercontent.com/39048846/41445834-2767f076-7087-11e8-9ac6-1034e958ba26.png">
