### PR TITLE
circleciの設定

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.4.4-node-browsers
+        environment:
+          RAILS_ENV: test
+      - image: circleci/mysql:5.6-ram
+        environment:
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Wait a booting mysql
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+      # Database setup
+      - run: bundle exec rake db:create
+      - run: bundle exec rake db:schema:load
+
+      # run tests!
+      - run:
+          name: run tests
+          command: bundle exec rspec
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,6 @@ jobs:
       - image: circleci/ruby:2.4.4-node-browsers
         environment:
           RAILS_ENV: test
-      - image: circleci/mysql:5.6-ram
-        environment:
-          MYSQL_USER: root
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
 
     working_directory: ~/repo
 
@@ -30,9 +26,6 @@ jobs:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Wait a booting mysql
-          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
       # Database setup
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load


### PR DESCRIPTION
# 目的
circleCI2.0をつかいruby 2.4を使う
# なぜ？
rubyのバージョンによってテストが落ちたので
# やったこと
- [x] .circleci/config.ymlの追加

SessionControllerのテストで&.のために変更しましたがセッションコントローラーのプルリクとは別なので新しく作りました
通ったら向こうにマージします