### PR TITLE
ユーザーの新規作成、ログイン時のリダイレクト先の変更、不要なアクションをremove

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: session_params[:email])
     if user&.authenticate(session_params[:password])
       log_in user
-      redirect_to user
+      redirect_to inquiries_path
     else
       flash.now[:danger] = 'メールアドレスかパスワードが間違っています'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,73 +1,23 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:show, :edit, :update, :destroy]
 
-  # GET /users
-  # GET /users.json
-  def index
-    @users = User.all
-  end
-
-  # GET /users/1
-  # GET /users/1.json
-  def show
-    @user = User.find(params[:id])
-  end
-
-  # GET /users/new
   def new
     @user = User.new
   end
 
-  # GET /users/1/edit
-  def edit
-  end
-
-  # POST /users
-  # POST /users.json
   def create
     @user = User.new(user_params)
 
     respond_to do |format|
       if @user.save
         log_in @user
-        format.html { redirect_to inquiries_path, notice: 'User was successfully created.' }
+        redirect_to inquiries_path
       else
-        format.html { render :new }
+        render :new
       end
-    end
-  end
-
-  # PATCH/PUT /users/1
-  # PATCH/PUT /users/1.json
-  def update
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to @user, notice: 'User was successfully updated.' }
-        format.json { render :show, status: :ok, location: @user }
-      else
-        format.html { render :edit }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /users/1
-  # DELETE /users/1.json
-  def destroy
-    @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
-      format.json { head :no_content }
     end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_user
-      @user = User.find(params[:id])
-    end
-
-    # Never trust parameters from the scary internet, only allow the white list through.
     def user_params
       params.require(:user).permit(:name, :email, :password)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,11 +29,10 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @user.save
-        format.html { redirect_to @user, notice: 'User was successfully created.' }
-        format.json { render :show, status: :created, location: @user }
+        log_in @user
+        format.html { redirect_to inquiries_path, notice: 'User was successfully created.' }
       else
         format.html { render :new }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,13 +7,11 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
 
-    respond_to do |format|
-      if @user.save
-        log_in @user
-        redirect_to inquiries_path
-      else
-        render :new
-      end
+    if @user.save
+      log_in @user
+      redirect_to inquiries_path
+    else
+      render :new
     end
   end
 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,8 +3,11 @@
     .container-fluid
       .navbar-header
         %a.navbar-brand 質問アプリ
+        - if logged_in?
+          %a.navbar-brand
+            = link_to "質問を投稿", new_inquiry_path, class: "navbar-brand"
         %a.navbar-brand
-          = link_to "質問を投稿", new_inquiry_path, class: "navbar-brand"
+          = link_to "質問を表示", inquiries_path, class: "navbar-brand"
       .collapse.navbar-collapse.navbar-right
         -if logged_in?
           .navbar-text

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @user do |f|
+= form_with model: @user, local: true do |f|
   - if @user.errors.any?
     #error_explanation
       %h2= "#{@user.errors.count} つのエラー"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SessionsController, type: :controller do
     context "login params is valid" do
       let(:user){create(:user)}
       before { post :create, params: { session: { email: user.email, password: user.password }} }
-      it { is_expected.to redirect_to user }
+      it { is_expected.to redirect_to inquiries_path }
     end
 
     context "login params is invalid" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe UsersController, type: :controller do
 
       it "redirects to the created user" do
         post :create, params: { user: user }
-        expect(response).to redirect_to(User.last)
+        expect(response).to redirect_to inquiries_path
       end
 
     end


### PR DESCRIPTION
# 目的
ユーザー新規作成時リダイレクト先変更andログイン
ログイン時のリダイレクト先変更
ユーザーコントローラーの実装しないメソッドを削除